### PR TITLE
Update time formatting to be more readable

### DIFF
--- a/main.go
+++ b/main.go
@@ -174,7 +174,7 @@ func (b *Bot) startZen(ev *slack.MessageEvent) {
 		Name:    name,
 		Channel: ev.Channel,
 		Reason:  reason,
-		EndsAt:  time.Now().Add(duration),
+		EndsAt:  time.Now().Add(duration).Format("15:04:05 (_2 Jan, MST)"),
 		Timeout: time.Now().Add(5 * time.Second),
 	}
 
@@ -182,7 +182,7 @@ func (b *Bot) startZen(ev *slack.MessageEvent) {
 	b.zens = append(b.zens, zen)
 	b.zensMutex.Unlock()
 
-	b.SendMessage(fmt.Sprintf("Added a zen for %s (%s), ends at [%s].", durationString, reason, zen.EndsAt), ev.Channel)
+	b.SendMessage(fmt.Sprintf("Added a zen for %s (%s), ends at %s.", durationString, reason, zen.EndsAt), ev.Channel)
 }
 
 func (b *Bot) cancelZen(ev *slack.MessageEvent) {

--- a/main.go
+++ b/main.go
@@ -174,7 +174,7 @@ func (b *Bot) startZen(ev *slack.MessageEvent) {
 		Name:    name,
 		Channel: ev.Channel,
 		Reason:  reason,
-		EndsAt:  time.Now().Add(duration).Format("15:04:05 (_2 Jan, MST)"),
+		EndsAt:  time.Now().Add(duration),
 		Timeout: time.Now().Add(5 * time.Second),
 	}
 
@@ -182,7 +182,7 @@ func (b *Bot) startZen(ev *slack.MessageEvent) {
 	b.zens = append(b.zens, zen)
 	b.zensMutex.Unlock()
 
-	b.SendMessage(fmt.Sprintf("Added a zen for %s (%s), ends at %s.", durationString, reason, zen.EndsAt), ev.Channel)
+	b.SendMessage(fmt.Sprintf("Added a zen for %s (%s), ends at %s.", durationString, reason, zen.EndsAt.Format("15:04:05 (_2 Jan, MST)")), ev.Channel)
 }
 
 func (b *Bot) cancelZen(ev *slack.MessageEvent) {


### PR DESCRIPTION
Before:
> Added a zen for 30m (work), ends at [2016-10-31 19:56:00.940413303 +0000 UTC].

After:
> Added a zen for 30m (work), ends at 19:56:00 (31 Oct, UTC).